### PR TITLE
Defer Experiments to post-MVP and add MVP roadmap

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -229,22 +229,7 @@ See [Data Dictionary](docs/data-dictionary.md) for database schema details.
 
 ---
 
-### 7. Experiments & A/B Comparisons
-
-**Purpose:** Allow users to formally test lifestyle interventions and compare results.
-
-**Feature Details:**
-- Create named experiments (e.g., "Testing magnesium for 30 days")
-- Set start and end dates
-- Compare two different periods/approaches side by side
-- Comprehensive comparison across all tracked data:
-  - Symptom frequency and severity
-  - Journal-based wellness scores (mood, energy, sleep quality)
-  - Lifestyle adherence rates
-
----
-
-### 8. Reports & Analytics
+### 7. Reports & Analytics
 
 #### Graphs and Statistics
 **Purpose:** Quick visualization of symptom patterns over time.
@@ -291,7 +276,7 @@ See [Data Dictionary](docs/data-dictionary.md) for database schema details.
 
 ---
 
-### 9. Data Export
+### 8. Data Export
 
 **Purpose:** Ensure users own their health data.
 
@@ -303,6 +288,12 @@ See [Data Dictionary](docs/data-dictionary.md) for database schema details.
 ---
 
 ## Post-MVP Features (Future Roadmap)
+
+### Experiments & A/B Comparisons
+- Create named experiments (e.g., "Testing magnesium for 30 days")
+- Set start and end dates
+- Compare two different periods/approaches side by side
+- Comprehensive comparison across all tracked data (symptom frequency/severity, journal-based wellness scores, lifestyle adherence rates)
 
 ### Medication/Supplement Interaction Warnings
 - Integrate with drug interaction database

--- a/database/README.md
+++ b/database/README.md
@@ -1,6 +1,6 @@
 # Flare Database Overview
 
-A health tracking database designed to help users log symptoms, track metrics, manage practices, and run personal experiments.
+A health tracking database designed to help users log symptoms, track metrics, and manage practices.
 
 ## Current Implementation Status
 
@@ -29,8 +29,6 @@ A health tracking database designed to help users log symptoms, track metrics, m
 │  medications ──────► medication_logs                            │
 │                                                                 │
 │  symptom_logs (standalone entries)                              │
-│                                                                 │
-│  experiments (ties practices to symptom monitoring)             │
 └─────────────────────────────────────────────────────────────────┘
                               │
                               ▼
@@ -82,21 +80,7 @@ FROM medication_logs
 WHERE medication_id = ? AND taken_at > NOW() - INTERVAL '30 days';
 ```
 
-### 4. Experiments
-Users create experiments to test if a practice helps specific symptoms.
-
-```sql
--- Compare symptom severity before/during an experiment
-SELECT
-  AVG(sl.severity) FILTER (WHERE sl.started_at < e.start_date) as baseline,
-  AVG(sl.severity) FILTER (WHERE sl.started_at >= e.start_date) as during_experiment
-FROM experiments e
-CROSS JOIN LATERAL unnest(e.target_symptoms::uuid[]) as target_symptom_id
-JOIN symptom_logs sl ON sl.symptom_type_id = target_symptom_id
-WHERE e.id = ? AND sl.user_id = e.user_id;
-```
-
-### 5. Correlation Discovery
+### 4. Correlation Discovery
 Find relationships between practices and symptom changes.
 
 ```sql

--- a/database/schema.dbml
+++ b/database/schema.dbml
@@ -289,31 +289,9 @@ Table medication_logs {
 }
 
 // ============================================
-// EXPERIMENTS
+// EXPERIMENTS (Post-MVP)
 // ============================================
-
-Table experiments {
-  id uuid [pk, default: `uuid_generate_v4()`]
-  user_id uuid [not null]
-  name text [not null]
-  description text
-  start_date date [not null]
-  end_date date
-  status text [default: 'active', note: 'active, completed, cancelled']
-  practice_ids jsonb [note: 'Related practices']
-  target_symptoms jsonb [note: 'symptom_type_ids to monitor']
-  notes text
-  created_at timestamp [default: `now()`]
-  updated_at timestamp [default: `now()`]
-
-  indexes {
-    user_id
-    (user_id, status)
-    (start_date, end_date)
-  }
-
-  note: 'User-defined experiments to test interventions'
-}
+// Deferred to post-MVP. Schema preserved for future implementation.
 
 // ============================================
 // TABLE GROUPS FOR VISUALIZATION
@@ -345,7 +323,6 @@ TableGroup user_logs {
 TableGroup user_config {
   practices
   medications
-  experiments
 }
 
 TableGroup symptom_links {

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -264,27 +264,28 @@ CREATE INDEX idx_medication_logs_medication ON medication_logs(medication_id);
 CREATE INDEX idx_medication_logs_user_date ON medication_logs(user_id, taken_at DESC);
 
 -- ============================================
--- EXPERIMENTS
+-- EXPERIMENTS (Post-MVP)
 -- ============================================
-
-CREATE TABLE experiments (
-    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-    user_id UUID NOT NULL,
-    name TEXT NOT NULL,
-    description TEXT,
-    start_date DATE NOT NULL,
-    end_date DATE,
-    status TEXT DEFAULT 'active' CHECK (status IN ('active', 'completed', 'cancelled')),
-    practice_ids JSONB,                    -- related practices
-    target_symptoms JSONB,                 -- symptom_type_ids to monitor
-    notes TEXT,
-    created_at TIMESTAMP WITH TIME ZONE DEFAULT now(),
-    updated_at TIMESTAMP WITH TIME ZONE DEFAULT now()
-);
-
-CREATE INDEX idx_experiments_user ON experiments(user_id);
-CREATE INDEX idx_experiments_user_status ON experiments(user_id, status);
-CREATE INDEX idx_experiments_dates ON experiments(start_date, end_date);
+-- Deferred to post-MVP. Schema preserved for future implementation.
+--
+-- CREATE TABLE experiments (
+--     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+--     user_id UUID NOT NULL,
+--     name TEXT NOT NULL,
+--     description TEXT,
+--     start_date DATE NOT NULL,
+--     end_date DATE,
+--     status TEXT DEFAULT 'active' CHECK (status IN ('active', 'completed', 'cancelled')),
+--     practice_ids JSONB,                    -- related practices
+--     target_symptoms JSONB,                 -- symptom_type_ids to monitor
+--     notes TEXT,
+--     created_at TIMESTAMP WITH TIME ZONE DEFAULT now(),
+--     updated_at TIMESTAMP WITH TIME ZONE DEFAULT now()
+-- );
+--
+-- CREATE INDEX idx_experiments_user ON experiments(user_id);
+-- CREATE INDEX idx_experiments_user_status ON experiments(user_id, status);
+-- CREATE INDEX idx_experiments_dates ON experiments(start_date, end_date);
 
 -- ============================================
 -- AUTHENTICATION & RATE LIMITING
@@ -407,9 +408,10 @@ CREATE TRIGGER update_medications_updated_at
     BEFORE UPDATE ON medications
     FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
-CREATE TRIGGER update_experiments_updated_at
-    BEFORE UPDATE ON experiments
-    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+-- Post-MVP: experiments trigger
+-- CREATE TRIGGER update_experiments_updated_at
+--     BEFORE UPDATE ON experiments
+--     FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
 -- ============================================
 -- COMMENTS
@@ -428,7 +430,7 @@ COMMENT ON TABLE practice_symptoms IS 'Links practices to symptoms they are expe
 COMMENT ON TABLE medications IS 'User medications and supplements';
 COMMENT ON TABLE medication_symptoms IS 'Links medications to symptoms they are expected to help';
 COMMENT ON TABLE medication_logs IS 'Medication adherence records';
-COMMENT ON TABLE experiments IS 'User-defined experiments to test interventions';
+-- Post-MVP: COMMENT ON TABLE experiments IS 'User-defined experiments to test interventions';
 COMMENT ON TABLE body_locations IS 'Reference table for anatomical locations';
 
 COMMENT ON COLUMN practices.tracking_type IS 'metric: tracked via metrics table, completion: mark done/skipped';

--- a/docs/data-dictionary.md
+++ b/docs/data-dictionary.md
@@ -601,24 +601,9 @@ medication_logs (
 )
 ```
 
-### Experiments
+### Experiments (Post-MVP)
 
-```sql
-experiments (
-  id UUID PRIMARY KEY,
-  user_id UUID NOT NULL,
-  name TEXT NOT NULL,
-  description TEXT,
-  start_date DATE NOT NULL,
-  end_date DATE,
-  status TEXT DEFAULT 'active',        -- 'active', 'completed', 'cancelled'
-  lifestyle_choice_ids JSONB,          -- related lifestyle choices
-  target_symptoms JSONB,               -- symptom_type_ids to monitor
-  notes TEXT,
-  created_at TIMESTAMP DEFAULT now(),
-  updated_at TIMESTAMP DEFAULT now()
-)
-```
+*Deferred to post-MVP. See PRD.md Post-MVP Features section.*
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,83 @@
+# Flare MVP — Feature Implementation Roadmap
+
+Last updated: 2026-02-13
+
+## Overview
+
+Features are implemented sequentially using speckit (specify → plan → tasks → implement). Auth (001) is complete. Each feature below builds on the ones before it.
+
+## Implementation Order
+
+| # | Feature | Branch | Depends On | Status |
+|---|---------|--------|------------|--------|
+| 001 | User Auth | `001-user-auth` | — | Done |
+| 002 | App Foundation | `002-app-foundation` | 001 | — |
+| 003 | Symptom Tracking | `003-symptom-tracking` | 002 | — |
+| 004 | Health Practices | `004-health-practices` | 003 | — |
+| 005 | Medication Tracking | `005-medication-tracking` | 004 | — |
+| 006 | Journal Entries | `006-journal-entries` | 004 | — |
+| 007 | Dashboard | `007-dashboard` | 003–006 | — |
+| 008 | Reminders & Notifications | `008-reminders-notifications` | 004–006 | — |
+| 009 | Reports & Analytics | `009-reports-analytics` | 003–006 | — |
+| 010 | Data Export | `010-data-export` | 003–006 | — |
+
+## Dependency Graph
+
+```
+001 Auth [done]
+ └─> 002 Foundation (schema, seed data, tabs, TanStack Query)
+      ├─> 003 Symptom Tracking
+      │    └─> 004 Health Practices
+      │         ├─> 005 Medication Tracking
+      │         └─> 006 Journal Entries (reuses metrics service)
+      │
+      ├─> 007 Dashboard (needs 003-006)
+      ├─> 008 Reminders (needs 004-006)
+      ├─> 009 Reports & Analytics (needs all data features)
+      └─> 010 Data Export (needs all data features)
+```
+
+## Feature Summaries
+
+### 002 — App Foundation
+Apply the full database schema as Supabase migrations (excluding `login_attempts` which exists). Add RLS policies for all tables. Seed predefined data (170+ symptom types, metric types, body locations, practice categories). Convert the app layout from Stack to tab navigator. Wire up TanStack Query.
+
+### 003 — Symptom Tracking
+Core data entry feature. Symptom logging form with category drill-down, severity 0-10, timing, body location, and notes. History/timeline view. Custom symptom creation. Establishes CRUD service layer patterns, category picker, and severity slider components.
+
+### 004 — Health Practices
+Daily task list — the primary engagement loop. Practice creation wizard with two tracking modes: completion (mark done/skipped) and metric (log numeric value). Symptom linking for AI correlation. Metric-type practices write to the shared `metrics` table.
+
+### 005 — Medication Tracking
+Similar UX to practices but separate data model. Medication CRUD with dosage, adherence logging (taken/skipped), and symptom linking. Reuses task list, symptom linker, and frequency config components from 004.
+
+### 006 — Journal Entries
+Morning and evening structured journals. Writes to the `metrics` table with `source = 'journal'` — not a separate table. Morning: sleep hours/quality, pain, energy. Evening: mood, energy, pain. Journal history and completion status tracking.
+
+### 007 — Dashboard
+Aggregation hub built after all data features. Today's practice + medication task list, progress rings, journal status, symptoms logged today, quick actions, frequent symptom tiles, and trend indicators (this week vs last week).
+
+### 008 — Reminders & Notifications
+Push notifications for practices, medications, and journals. Permission flow, local notification scheduling from `reminder_times`, deep link handling on tap, and notification preferences in settings.
+
+### 009 — Reports & Analytics
+Three sub-phases: (a) Charts — line charts, calendar heatmaps, milestone markers, multi-symptom overlay. (b) AI Insights — Python FastAPI + LangChain service for correlation detection and pattern recognition. (c) Doctor Reports — comprehensive health summary with PDF export.
+
+### 010 — Data Export
+CSV and JSON export of all user data. Export UI in settings with date range and data type selection.
+
+## Post-MVP (Deferred)
+
+- Experiments & A/B Comparisons
+- Home screen widget for quick logging
+- Social authentication (Google, Apple Sign-In)
+- Medication interaction warnings
+- On-device AI option
+- Community/social features
+
+## Key Architectural Notes
+
+- **Database schema applied upfront** in 002, not incrementally per feature.
+- **`metrics` table is shared** — practices (metric-type), journals, and future integrations all write to it with different `source` values.
+- **Journals have no dedicated table** — they write structured metric records with `source = 'journal'`.
+- **Dashboard built last among data features** to avoid incremental rework. Tab navigator from 002 provides navigation in the interim.


### PR DESCRIPTION
## Summary
- Move Experiments & A/B Comparisons from MVP scope to post-MVP across all documentation and schema files
- Add `docs/roadmap.md` with the full 9-feature implementation sequence (002–010), dependency graph, and feature summaries
- Renumber PRD sections (Reports → 7, Data Export → 8) to fill the gap

## Files changed
- `PRD.md` — Experiments moved to Post-MVP Features, sections renumbered
- `database/schema.sql` — Experiments table commented out (preserved for future)
- `database/schema.dbml` — Experiments entity removed, TableGroup updated
- `database/README.md` — Experiments removed from diagram and queries
- `docs/data-dictionary.md` — Experiments schema replaced with post-MVP note
- `docs/roadmap.md` — **New** — Full MVP implementation roadmap

## Test plan
- [ ] Verify all markdown renders correctly on GitHub
- [ ] Confirm no broken cross-references in documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)