### PR TITLE
Add interactive MVP wireframes and project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,80 @@
+# Flare
+
+A privacy-first health tracking app for people managing invisible illnesses, undiagnosed conditions, and autoimmune disorders. Track symptoms, medications, and lifestyle choices to uncover patterns that improve your wellbeing.
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|------------|
+| Mobile | React Native (Expo 54) — iOS, Android, Web |
+| Navigation | Expo Router 6 (file-based routing) |
+| Backend | Supabase (PostgreSQL, Auth, RLS, Edge Functions) |
+| AI Service | Python, FastAPI, LangChain (planned) |
+| Testing | Jest + React Native Testing Library |
+
+## Getting Started
+
+```bash
+npm install
+```
+
+Create a `.env.local` with your Supabase credentials:
+
+```
+EXPO_PUBLIC_SUPABASE_URL=your_supabase_url
+EXPO_PUBLIC_SUPABASE_ANON_KEY=your_anon_key
+```
+
+Then start the dev server:
+
+```bash
+npm start
+```
+
+Or target a specific platform:
+
+```bash
+npm run ios        # iOS simulator
+npm run android    # Android emulator
+npm run web        # Web browser
+```
+
+## Testing & Linting
+
+```bash
+npm test           # Run test suite
+npm run lint       # Run ESLint
+```
+
+## Project Structure
+
+```
+app/                     # Expo Router screens
+  (auth)/                #   Login, signup, password reset
+  (app)/                 #   Authenticated app screens
+src/
+  services/              # Supabase client, auth, encryption
+  contexts/              # Auth state management
+docs/                    # Data dictionary, architecture, roadmap
+specs/                   # Feature specifications
+```
+
+## Privacy & Security
+
+- Tokens stored in device keychain via `expo-secure-store`
+- Row-level security (RLS) isolates user data at the database level
+- AES-256 encryption at rest, TLS in transit
+- User data anonymized before AI processing
+- Compliant with FTC Health Breach Notification Rule
+
+## Current Status
+
+**Auth system** — complete and merged (signup, signin, password reset, rate limiting, secure token storage, full test suite).
+
+**App foundation** — in progress (dashboard, data models, Supabase schema).
+
+See [prd.md](prd.md) for the full product requirements and roadmap.
+
+## License
+
+All rights reserved.

--- a/wireframes/flare-mvp.html
+++ b/wireframes/flare-mvp.html
@@ -1,0 +1,2087 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Flare — MVP Wireframes</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" rel="stylesheet">
+<style>
+/* ═══════════ THEME VARIABLES ═══════════ */
+:root {
+  --primary: #4A9B8E;
+  --primary-container: #C8E6E0;
+  --on-primary: #FFFFFF;
+  --on-primary-container: #003731;
+  --secondary: #7B89C3;
+  --secondary-container: #DFE3F2;
+  --on-secondary: #FFFFFF;
+  --on-secondary-container: #1B2560;
+  --tertiary: #86C5A8;
+  --tertiary-container: #D9F0E3;
+  --surface: #FAF9F7;
+  --surface-variant: #E8E5E0;
+  --surface-container: #F0EEEB;
+  --surface-container-high: #E8E6E3;
+  --background: #FCFBF9;
+  --on-surface: #1C1B1F;
+  --on-surface-variant: #49454F;
+  --outline: #7A7680;
+  --outline-variant: #CBC5D0;
+  --error: #BA1A1A;
+  --error-container: #FFDAD6;
+  --shadow: rgba(0,0,0,0.12);
+}
+
+/* ═══════════ RESET & BASE ═══════════ */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+body {
+  font-family: 'Roboto', sans-serif;
+  background: #E8E5E0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 24px;
+  color: var(--on-surface);
+}
+.material-symbols-outlined {
+  font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+  user-select: none;
+}
+.material-symbols-outlined.filled {
+  font-variation-settings: 'FILL' 1, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+}
+
+/* ═══════════ PAGE LAYOUT ═══════════ */
+.page-header {
+  text-align: center;
+  margin-bottom: 20px;
+  color: var(--on-surface-variant);
+}
+.page-header h1 {
+  font-size: 20px;
+  font-weight: 500;
+  letter-spacing: 0.5px;
+  color: var(--on-surface);
+}
+.page-header p { font-size: 13px; margin-top: 4px; }
+
+.page-wrapper {
+  display: flex;
+  gap: 24px;
+  align-items: flex-start;
+}
+
+/* ═══════════ SCREEN NAV SIDEBAR ═══════════ */
+.screen-nav {
+  width: 180px;
+  background: var(--surface);
+  border-radius: 16px;
+  padding: 16px;
+  box-shadow: 0 1px 3px var(--shadow);
+  position: sticky;
+  top: 24px;
+}
+.screen-nav h3 {
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--on-surface-variant);
+  margin-bottom: 12px;
+  padding: 0 4px;
+}
+.screen-nav .nav-group { margin-bottom: 16px; }
+.screen-nav .nav-group:last-child { margin-bottom: 0; }
+.screen-nav .nav-label {
+  font-size: 10px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  color: var(--outline);
+  margin-bottom: 6px;
+  padding: 0 4px;
+}
+.screen-nav button {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  padding: 8px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-family: inherit;
+  color: var(--on-surface);
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.screen-nav button:hover { background: var(--surface-variant); }
+.screen-nav button.active { background: var(--primary-container); color: var(--on-primary-container); font-weight: 500; }
+
+/* ═══════════ PHONE FRAME ═══════════ */
+.phone {
+  width: 375px;
+  height: 812px;
+  background: var(--background);
+  border-radius: 44px;
+  box-shadow: 0 8px 40px rgba(0,0,0,0.18), 0 2px 8px rgba(0,0,0,0.08);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  flex-shrink: 0;
+  border: 6px solid #1C1C1E;
+}
+
+/* ═══════════ STATUS BAR ═══════════ */
+.status-bar {
+  height: 50px;
+  padding: 14px 24px 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-shrink: 0;
+  background: var(--background);
+  z-index: 5;
+}
+.status-bar .time { font-size: 15px; font-weight: 600; }
+.status-bar .icons { display: flex; gap: 4px; align-items: center; }
+.status-bar .icons .material-symbols-outlined { font-size: 17px; }
+
+/* ═══════════ SCREEN AREA ═══════════ */
+.screen-area {
+  flex: 1;
+  overflow: hidden;
+  position: relative;
+}
+.screen {
+  position: absolute;
+  top: 0; left: 0; right: 0; bottom: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  background: var(--background);
+  display: none;
+  flex-direction: column;
+  -webkit-overflow-scrolling: touch;
+}
+.screen.active { display: flex; }
+.screen::-webkit-scrollbar { display: none; }
+.screen-content { padding: 0 16px 24px; flex: 1; }
+
+/* ═══════════ BOTTOM NAVIGATION ═══════════ */
+.bottom-nav {
+  height: 80px;
+  background: var(--surface);
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  flex-shrink: 0;
+  border-top: 1px solid var(--surface-variant);
+  z-index: 5;
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+.phone.modal-open .bottom-nav { transform: translateY(100%); }
+.tab-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  position: relative;
+  min-width: 56px;
+  font-family: inherit;
+}
+.tab-btn .icon-wrap {
+  width: 56px;
+  height: 32px;
+  border-radius: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s;
+}
+.tab-btn.active .icon-wrap { background: var(--primary-container); }
+.tab-btn .material-symbols-outlined { font-size: 24px; color: var(--on-surface-variant); transition: color 0.2s; }
+.tab-btn.active .material-symbols-outlined { color: var(--on-primary-container); font-variation-settings: 'FILL' 1, 'wght' 400, 'GRAD' 0, 'opsz' 24; }
+.tab-btn .label { font-size: 12px; font-weight: 500; color: var(--on-surface-variant); }
+.tab-btn.active .label { color: var(--on-primary-container); }
+
+/* ═══════════ APP BAR ═══════════ */
+.app-bar {
+  padding: 8px 16px 12px;
+  flex-shrink: 0;
+}
+.app-bar h1 { font-size: 24px; font-weight: 400; color: var(--on-surface); }
+.app-bar-small { padding: 4px 16px 8px; }
+.app-bar-small h1 { font-size: 20px; }
+
+/* ═══════════ MD3 COMPONENTS ═══════════ */
+
+/* Card */
+.card {
+  background: var(--surface);
+  border-radius: 12px;
+  padding: 16px;
+  margin-bottom: 12px;
+  box-shadow: 0 1px 2px var(--shadow);
+}
+.card-title {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--on-surface-variant);
+  margin-bottom: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+/* Filled Button */
+.btn-filled {
+  background: var(--primary);
+  color: var(--on-primary);
+  border: none;
+  border-radius: 20px;
+  padding: 10px 24px;
+  font-size: 14px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  transition: all 0.15s;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.btn-filled:hover { box-shadow: 0 1px 3px var(--shadow); filter: brightness(1.05); }
+.btn-filled:active { transform: scale(0.98); }
+.btn-filled.full-width { width: 100%; justify-content: center; }
+
+/* Tonal Button */
+.btn-tonal {
+  background: var(--primary-container);
+  color: var(--on-primary-container);
+  border: none;
+  border-radius: 20px;
+  padding: 10px 16px;
+  font-size: 13px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  transition: all 0.15s;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+.btn-tonal:hover { filter: brightness(0.96); }
+.btn-tonal:active { transform: scale(0.97); }
+
+/* Outlined Button */
+.btn-outlined {
+  background: transparent;
+  color: var(--primary);
+  border: 1px solid var(--outline);
+  border-radius: 20px;
+  padding: 10px 24px;
+  font-size: 14px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  transition: all 0.15s;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.btn-outlined:hover { background: rgba(74,155,142,0.08); }
+.btn-outlined.full-width { width: 100%; justify-content: center; }
+.btn-outlined.error { color: var(--error); border-color: var(--error); }
+.btn-outlined.error:hover { background: rgba(186,26,26,0.08); }
+
+/* Text Button */
+.btn-text {
+  background: none;
+  border: none;
+  color: var(--primary);
+  font-size: 14px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  padding: 10px 12px;
+  border-radius: 20px;
+}
+.btn-text:hover { background: rgba(74,155,142,0.08); }
+
+/* Chip */
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border-radius: 8px;
+  border: 1px solid var(--outline-variant);
+  background: var(--surface);
+  font-size: 13px;
+  font-weight: 500;
+  font-family: inherit;
+  color: var(--on-surface);
+  cursor: pointer;
+  transition: all 0.15s;
+  white-space: nowrap;
+}
+.chip:hover { background: var(--surface-variant); }
+.chip.active {
+  background: var(--primary-container);
+  border-color: transparent;
+  color: var(--on-primary-container);
+}
+.chip .material-symbols-outlined { font-size: 18px; }
+.chip-row { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 16px; }
+
+/* Segmented Buttons */
+.seg-group {
+  display: flex;
+  border: 1px solid var(--outline);
+  border-radius: 20px;
+  overflow: hidden;
+  margin-bottom: 16px;
+}
+.seg-btn {
+  flex: 1;
+  padding: 8px 16px;
+  border: none;
+  background: none;
+  font-size: 13px;
+  font-weight: 500;
+  font-family: inherit;
+  color: var(--on-surface);
+  cursor: pointer;
+  transition: all 0.15s;
+  border-right: 1px solid var(--outline);
+}
+.seg-btn:last-child { border-right: none; }
+.seg-btn.active { background: var(--primary-container); color: var(--on-primary-container); }
+
+/* FAB */
+.fab {
+  position: absolute;
+  bottom: 16px;
+  right: 16px;
+  width: 56px;
+  height: 56px;
+  border-radius: 16px;
+  background: var(--primary-container);
+  border: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: 0 3px 8px rgba(0,0,0,0.2);
+  transition: all 0.2s;
+  z-index: 3;
+}
+.fab:hover { box-shadow: 0 6px 16px rgba(0,0,0,0.24); transform: scale(1.04); }
+.fab .material-symbols-outlined { font-size: 28px; color: var(--on-primary-container); }
+
+/* List Item */
+.list-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  min-height: 56px;
+  cursor: pointer;
+  transition: background 0.12s;
+  border-radius: 8px;
+}
+.list-item:hover { background: rgba(74,155,142,0.06); }
+.list-item .leading { color: var(--on-surface-variant); display: flex; }
+.list-item .leading .material-symbols-outlined { font-size: 24px; }
+.list-item .content { flex: 1; min-width: 0; }
+.list-item .headline { font-size: 15px; color: var(--on-surface); }
+.list-item .supporting { font-size: 13px; color: var(--on-surface-variant); margin-top: 2px; }
+.list-item .trailing { color: var(--on-surface-variant); display: flex; align-items: center; }
+.list-item .trailing .material-symbols-outlined { font-size: 20px; }
+
+/* Section Header */
+.section-header {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--on-surface-variant);
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  padding: 16px 16px 8px;
+}
+
+/* Divider */
+.divider { height: 1px; background: var(--surface-variant); margin: 0 16px; }
+
+/* Text Input (outlined) */
+.input-outlined {
+  width: 100%;
+  padding: 14px 16px;
+  border: 1px solid var(--outline);
+  border-radius: 4px;
+  font-size: 15px;
+  font-family: inherit;
+  background: transparent;
+  color: var(--on-surface);
+  outline: none;
+  transition: border-color 0.15s;
+}
+.input-outlined:focus { border-color: var(--primary); border-width: 2px; padding: 13px 15px; }
+.input-label {
+  font-size: 12px;
+  color: var(--on-surface-variant);
+  margin-bottom: 6px;
+  display: block;
+}
+
+/* Range Slider */
+.slider-group { margin-bottom: 20px; }
+.slider-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 8px;
+}
+.slider-title { font-size: 14px; color: var(--on-surface); font-weight: 500; }
+.slider-value { font-size: 24px; font-weight: 300; color: var(--primary); }
+.slider-label-text { font-size: 12px; color: var(--on-surface-variant); text-align: right; }
+input[type="range"] {
+  -webkit-appearance: none;
+  width: 100%;
+  height: 4px;
+  border-radius: 2px;
+  background: var(--surface-variant);
+  outline: none;
+}
+input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--primary);
+  cursor: pointer;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.2);
+}
+
+/* Severity Badge */
+.severity-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 24px;
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: 500;
+  color: white;
+}
+.severity-low { background: var(--primary); }
+.severity-mid { background: #C4922A; }
+.severity-high { background: #C25E3F; }
+.severity-critical { background: var(--error); }
+
+/* Task Item */
+.task-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 0;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+.task-check {
+  width: 22px;
+  height: 22px;
+  border-radius: 4px;
+  border: 2px solid var(--outline);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: all 0.15s;
+}
+.task-item.done .task-check {
+  background: var(--primary);
+  border-color: var(--primary);
+}
+.task-item.done .task-check::after {
+  content: '✓';
+  color: white;
+  font-size: 14px;
+  font-weight: 700;
+}
+.task-icon { color: var(--on-surface-variant); display: flex; }
+.task-icon .material-symbols-outlined { font-size: 20px; }
+.task-info { flex: 1; min-width: 0; }
+.task-name { font-size: 14px; color: var(--on-surface); transition: all 0.2s; }
+.task-meta { font-size: 12px; color: var(--on-surface-variant); margin-top: 1px; }
+.task-item.done .task-name { text-decoration: line-through; opacity: 0.5; }
+.task-item.done .task-meta { opacity: 0.4; }
+.task-metric {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--primary);
+  white-space: nowrap;
+}
+
+/* Progress Ring */
+.progress-ring-wrap {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 8px 0 4px;
+  margin-bottom: 8px;
+}
+.progress-ring-wrap svg { flex-shrink: 0; }
+.progress-ring-info h2 { font-size: 20px; font-weight: 400; }
+.progress-ring-info p { font-size: 13px; color: var(--on-surface-variant); margin-top: 2px; }
+
+/* Trend Item */
+.trend-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 0;
+}
+.trend-icon { font-size: 18px; }
+.trend-name { font-size: 14px; flex: 1; }
+.trend-detail { font-size: 12px; color: var(--on-surface-variant); }
+.trend-up { color: #2E7D32; }
+.trend-down { color: #2E7D32; }
+.trend-same { color: var(--on-surface-variant); }
+
+/* Quick Actions */
+.quick-actions { display: flex; gap: 8px; margin-bottom: 16px; }
+.quick-actions .btn-tonal { flex: 1; justify-content: center; font-size: 12px; padding: 10px 8px; }
+
+/* ═══════════ MODAL SYSTEM ═══════════ */
+.modal-overlay {
+  position: absolute;
+  top: 0; left: 0; right: 0; bottom: 0;
+  z-index: 20;
+  background: var(--background);
+  transform: translateY(100%);
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.modal-overlay.active { transform: translateY(0); }
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  padding: 12px 8px;
+  flex-shrink: 0;
+  gap: 4px;
+}
+.modal-close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 20px;
+  display: flex;
+  color: var(--on-surface);
+}
+.modal-close:hover { background: var(--surface-variant); }
+.modal-title { font-size: 18px; font-weight: 500; flex: 1; }
+.modal-step { font-size: 13px; color: var(--on-surface-variant); padding-right: 12px; }
+
+.modal-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0 16px;
+}
+.modal-body::-webkit-scrollbar { display: none; }
+
+.modal-footer {
+  padding: 12px 16px 24px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-shrink: 0;
+  gap: 12px;
+  background: var(--background);
+}
+
+/* Wizard Steps */
+.wizard-step { display: none; }
+.wizard-step.active { display: block; }
+
+/* Category Cards (Log Symptom step 1) */
+.category-card {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 20px;
+  background: var(--surface);
+  border-radius: 12px;
+  margin-bottom: 12px;
+  cursor: pointer;
+  border: 2px solid transparent;
+  transition: all 0.15s;
+}
+.category-card:hover { border-color: var(--primary-container); background: var(--surface-container); }
+.category-card.selected { border-color: var(--primary); background: var(--primary-container); }
+.category-card .cat-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  background: var(--primary-container);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.category-card.selected .cat-icon { background: var(--primary); }
+.category-card.selected .cat-icon .material-symbols-outlined { color: var(--on-primary); }
+.category-card .cat-icon .material-symbols-outlined { font-size: 28px; color: var(--primary); }
+.category-card .cat-label { font-size: 16px; font-weight: 500; }
+.category-card .cat-desc { font-size: 13px; color: var(--on-surface-variant); margin-top: 2px; }
+
+/* Symptom picker list */
+.symptom-option {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.12s;
+}
+.symptom-option:hover { background: var(--surface-container); }
+.symptom-option.selected { background: var(--primary-container); }
+.symptom-option .radio {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 2px solid var(--outline);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+.symptom-option.selected .radio {
+  border-color: var(--primary);
+  background: var(--primary);
+}
+.symptom-option.selected .radio::after {
+  content: '';
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: white;
+}
+
+/* Radio Group */
+.radio-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.12s;
+}
+.radio-option:hover { background: var(--surface-container); }
+.radio-option.selected { background: var(--primary-container); }
+.radio-option .radio-circle {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 2px solid var(--outline);
+  flex-shrink: 0;
+  margin-top: 1px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s;
+}
+.radio-option.selected .radio-circle { border-color: var(--primary); }
+.radio-option.selected .radio-circle::after {
+  content: '';
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--primary);
+}
+.radio-label { font-size: 15px; }
+.radio-desc { font-size: 13px; color: var(--on-surface-variant); margin-top: 2px; }
+
+/* Toggle Switch */
+.toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 0;
+}
+.toggle {
+  width: 48px;
+  height: 28px;
+  border-radius: 14px;
+  background: var(--surface-variant);
+  border: 2px solid var(--outline);
+  cursor: pointer;
+  position: relative;
+  transition: all 0.2s;
+}
+.toggle.on { background: var(--primary); border-color: var(--primary); }
+.toggle::after {
+  content: '';
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--outline);
+  top: 2px;
+  left: 2px;
+  transition: all 0.2s;
+}
+.toggle.on::after { left: 22px; background: white; }
+
+/* Checkbox */
+.checkbox-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 0;
+  cursor: pointer;
+}
+.checkbox-box {
+  width: 20px;
+  height: 20px;
+  border: 2px solid var(--outline);
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: all 0.15s;
+}
+.checkbox-item.checked .checkbox-box {
+  background: var(--primary);
+  border-color: var(--primary);
+}
+.checkbox-item.checked .checkbox-box::after {
+  content: '✓';
+  color: white;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+/* Day Chips */
+.day-chips { display: flex; gap: 6px; margin: 12px 0; }
+.day-chip {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 1px solid var(--outline-variant);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+  background: none;
+  font-family: inherit;
+}
+.day-chip.active { background: var(--primary); color: white; border-color: var(--primary); }
+
+/* Insight Card */
+.insight-card {
+  background: var(--surface);
+  border-radius: 12px;
+  padding: 16px;
+  margin-bottom: 12px;
+  border-left: 3px solid var(--secondary);
+}
+.insight-card .insight-icon { color: var(--secondary); margin-bottom: 6px; }
+.insight-card p { font-size: 14px; line-height: 1.5; color: var(--on-surface); }
+
+/* Report Section Card */
+.report-card {
+  background: var(--surface);
+  border-radius: 12px;
+  padding: 16px;
+  margin-bottom: 12px;
+  box-shadow: 0 1px 2px var(--shadow);
+}
+.report-card h3 { font-size: 14px; font-weight: 500; margin-bottom: 10px; color: var(--on-surface); }
+.report-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 0;
+  font-size: 13px;
+}
+.report-row .label { color: var(--on-surface); }
+.report-row .value { color: var(--on-surface-variant); font-weight: 500; }
+
+/* Form spacing */
+.form-group { margin-bottom: 20px; }
+
+/* Inline fields */
+.inline-fields { display: flex; gap: 12px; }
+.inline-fields > * { flex: 1; }
+
+/* SVG Chart */
+.chart-container {
+  background: var(--surface);
+  border-radius: 12px;
+  padding: 16px;
+  margin-bottom: 16px;
+}
+
+/* Disclaimer */
+.disclaimer {
+  font-size: 12px;
+  color: var(--on-surface-variant);
+  font-style: italic;
+  padding: 12px 0;
+  line-height: 1.4;
+}
+
+/* Misc */
+.empty-state { text-align: center; padding: 40px 24px; color: var(--on-surface-variant); }
+.empty-state .material-symbols-outlined { font-size: 48px; margin-bottom: 12px; opacity: 0.4; }
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 12px;
+  border-radius: 16px;
+  background: var(--secondary-container);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--on-secondary-container);
+}
+.spacer { height: 16px; }
+.spacer-sm { height: 8px; }
+
+/* ═══════════ ANIMATIONS ═══════════ */
+@keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+.screen.active { animation: fadeIn 0.2s ease; }
+@keyframes ringDraw {
+  from { stroke-dasharray: 0 314; }
+}
+.progress-arc { animation: ringDraw 1s ease-out forwards; }
+</style>
+</head>
+<body>
+
+<div class="page-header">
+  <h1>Flare — MVP Wireframes</h1>
+  <p>Interactive prototype &middot; Click through tabs and buttons to explore</p>
+</div>
+
+<div class="page-wrapper">
+
+<!-- ═══════════ SCREEN NAV SIDEBAR ═══════════ -->
+<div class="screen-nav" id="screenNav">
+  <h3>Screens</h3>
+  <div class="nav-group">
+    <div class="nav-label">Tabs</div>
+    <button class="active" onclick="goTo('home')">Home</button>
+    <button onclick="goTo('symptoms')">Symptoms</button>
+    <button onclick="goTo('practices')">Practices</button>
+    <button onclick="goTo('insights')">Insights</button>
+    <button onclick="goTo('settings')">Settings</button>
+  </div>
+  <div class="nav-group">
+    <div class="nav-label">Modals</div>
+    <button onclick="openModal('log-symptom')">Log Symptom</button>
+    <button onclick="openModal('create-practice')">Create Practice</button>
+    <button onclick="openModal('morning-journal')">Morning Journal</button>
+    <button onclick="openModal('evening-journal')">Evening Journal</button>
+    <button onclick="openModal('add-medication')">Add Medication</button>
+    <button onclick="openModal('doctor-report')">Doctor Report</button>
+  </div>
+</div>
+
+<!-- ═══════════ PHONE ═══════════ -->
+<div class="phone" id="phone">
+
+  <!-- Status Bar -->
+  <div class="status-bar">
+    <span class="time">9:41</span>
+    <div class="icons">
+      <span class="material-symbols-outlined" style="font-size:15px">signal_cellular_alt</span>
+      <span class="material-symbols-outlined" style="font-size:15px">wifi</span>
+      <span class="material-symbols-outlined" style="font-size:15px">battery_full</span>
+    </div>
+  </div>
+
+  <!-- Screen Area -->
+  <div class="screen-area">
+
+    <!-- ═══════════ 1. HOME ═══════════ -->
+    <div class="screen active" id="screen-home" data-tab="home">
+      <div class="app-bar">
+        <h1>Good morning, Jordan</h1>
+      </div>
+      <div class="screen-content">
+
+        <!-- Progress Ring -->
+        <div class="card">
+          <div class="progress-ring-wrap">
+            <svg width="80" height="80" viewBox="0 0 120 120">
+              <circle cx="60" cy="60" r="50" fill="none" stroke="var(--surface-variant)" stroke-width="8"/>
+              <circle class="progress-arc" cx="60" cy="60" r="50" fill="none" stroke="var(--primary)" stroke-width="8" stroke-linecap="round" transform="rotate(-90 60 60)" stroke-dasharray="196 314" id="progressArc"/>
+            </svg>
+            <div class="progress-ring-info">
+              <h2 id="progressText">5/8 tasks</h2>
+              <p>today's progress</p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Today's Tasks -->
+        <div class="card">
+          <div class="card-title">Today's Tasks</div>
+          <div id="taskList">
+            <div class="task-item done" onclick="toggleTask(this)">
+              <div class="task-check"></div>
+              <div class="task-icon"><span class="material-symbols-outlined">directions_walk</span></div>
+              <div class="task-info"><div class="task-name">Morning walk</div><div class="task-meta">7:30 AM</div></div>
+            </div>
+            <div class="task-item done" onclick="toggleTask(this)">
+              <div class="task-check"></div>
+              <div class="task-icon"><span class="material-symbols-outlined">local_drink</span></div>
+              <div class="task-info"><div class="task-name">Drink adrenal cocktail</div><div class="task-meta">8:00 AM</div></div>
+            </div>
+            <div class="task-item" onclick="toggleTask(this)">
+              <div class="task-check"></div>
+              <div class="task-icon"><span class="material-symbols-outlined">medication</span></div>
+              <div class="task-info"><div class="task-name">Take magnesium</div><div class="task-meta">9:00 AM</div></div>
+            </div>
+            <div class="task-item" onclick="toggleTask(this)">
+              <div class="task-check"></div>
+              <div class="task-icon"><span class="material-symbols-outlined">fitness_center</span></div>
+              <div class="task-info"><div class="task-name">Pilates routine</div><div class="task-meta">3x/week</div></div>
+            </div>
+            <div class="task-item done" onclick="toggleTask(this)">
+              <div class="task-check"></div>
+              <div class="task-icon"><span class="material-symbols-outlined">medication</span></div>
+              <div class="task-info"><div class="task-name">Take Vitamin D</div><div class="task-meta">12:00 PM</div></div>
+            </div>
+            <div class="task-item" onclick="toggleTask(this)">
+              <div class="task-check"></div>
+              <div class="task-icon"><span class="material-symbols-outlined">water_drop</span></div>
+              <div class="task-info"><div class="task-name">Hydration tracking</div><div class="task-meta">Daily goal</div></div>
+              <div class="task-metric">4/8 glasses</div>
+            </div>
+            <div class="task-item done" onclick="toggleTask(this)">
+              <div class="task-check"></div>
+              <div class="task-icon"><span class="material-symbols-outlined">self_improvement</span></div>
+              <div class="task-info"><div class="task-name">Evening meditation</div><div class="task-meta">Daily</div></div>
+            </div>
+            <div class="task-item done" onclick="toggleTask(this)">
+              <div class="task-check"></div>
+              <div class="task-icon"><span class="material-symbols-outlined">medication</span></div>
+              <div class="task-info"><div class="task-name">Take magnesium</div><div class="task-meta">9:00 PM</div></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Quick Actions -->
+        <div class="quick-actions">
+          <button class="btn-tonal" onclick="openModal('log-symptom')">
+            <span class="material-symbols-outlined" style="font-size:18px">add_circle</span>
+            Log Symptom
+          </button>
+          <button class="btn-tonal" onclick="openModal('morning-journal')">
+            <span class="material-symbols-outlined" style="font-size:18px">wb_sunny</span>
+            AM Journal
+          </button>
+          <button class="btn-tonal" onclick="openModal('evening-journal')">
+            <span class="material-symbols-outlined" style="font-size:18px">dark_mode</span>
+            PM Journal
+          </button>
+        </div>
+
+        <!-- Frequent Symptoms -->
+        <div class="card">
+          <div class="card-title">Quick Log</div>
+          <div class="chip-row" style="margin-bottom:0">
+            <button class="chip" onclick="quickLogSymptom('Migraine')">
+              <span class="material-symbols-outlined" style="font-size:16px">bolt</span> Migraine
+            </button>
+            <button class="chip" onclick="quickLogSymptom('Brain fog')">
+              <span class="material-symbols-outlined" style="font-size:16px">cloud</span> Brain fog
+            </button>
+            <button class="chip" onclick="quickLogSymptom('Fatigue')">
+              <span class="material-symbols-outlined" style="font-size:16px">battery_2_bar</span> Fatigue
+            </button>
+            <button class="chip" onclick="quickLogSymptom('Joint pain')">
+              <span class="material-symbols-outlined" style="font-size:16px">accessibility</span> Joint pain
+            </button>
+          </div>
+        </div>
+
+        <!-- Trends -->
+        <div class="card">
+          <div class="card-title">This Week</div>
+          <div class="trend-item">
+            <span class="material-symbols-outlined trend-icon trend-down">south</span>
+            <span class="trend-name">Migraine</span>
+            <span class="trend-detail trend-down">↓ 2 fewer</span>
+          </div>
+          <div class="trend-item">
+            <span class="material-symbols-outlined trend-icon trend-same">east</span>
+            <span class="trend-name">Fatigue</span>
+            <span class="trend-detail trend-same">→ same</span>
+          </div>
+          <div class="trend-item">
+            <span class="material-symbols-outlined trend-icon trend-up">north</span>
+            <span class="trend-name">Sleep quality</span>
+            <span class="trend-detail trend-up">↑ improving</span>
+          </div>
+        </div>
+
+        <div class="spacer"></div>
+      </div>
+    </div>
+
+    <!-- ═══════════ 2. SYMPTOMS ═══════════ -->
+    <div class="screen" id="screen-symptoms" data-tab="symptoms">
+      <div class="app-bar">
+        <h1>Symptoms</h1>
+      </div>
+      <div class="screen-content">
+        <div class="chip-row">
+          <button class="chip active" onclick="filterChip(this)">All</button>
+          <button class="chip" onclick="filterChip(this)">Physical</button>
+          <button class="chip" onclick="filterChip(this)">Mental</button>
+          <button class="chip" onclick="filterChip(this)">Sleep</button>
+        </div>
+
+        <div class="list-item">
+          <div class="leading"><span class="material-symbols-outlined">bolt</span></div>
+          <div class="content">
+            <div class="headline">Migraine</div>
+            <div class="supporting">2 hours ago &middot; Head, left temple</div>
+          </div>
+          <div class="trailing"><span class="severity-badge severity-high">7</span></div>
+        </div>
+        <div class="divider"></div>
+        <div class="list-item">
+          <div class="leading"><span class="material-symbols-outlined">cloud</span></div>
+          <div class="content">
+            <div class="headline">Brain fog</div>
+            <div class="supporting">4 hours ago</div>
+          </div>
+          <div class="trailing"><span class="severity-badge severity-mid">5</span></div>
+        </div>
+        <div class="divider"></div>
+        <div class="list-item">
+          <div class="leading"><span class="material-symbols-outlined">accessibility</span></div>
+          <div class="content">
+            <div class="headline">Joint pain (knees)</div>
+            <div class="supporting">Yesterday, 3:20 PM</div>
+          </div>
+          <div class="trailing"><span class="severity-badge severity-mid">6</span></div>
+        </div>
+        <div class="divider"></div>
+        <div class="list-item">
+          <div class="leading"><span class="material-symbols-outlined">battery_2_bar</span></div>
+          <div class="content">
+            <div class="headline">Fatigue</div>
+            <div class="supporting">Yesterday, 11:00 AM</div>
+          </div>
+          <div class="trailing"><span class="severity-badge severity-low">4</span></div>
+        </div>
+        <div class="divider"></div>
+        <div class="list-item">
+          <div class="leading"><span class="material-symbols-outlined">bed</span></div>
+          <div class="content">
+            <div class="headline">Insomnia</div>
+            <div class="supporting">2 days ago</div>
+          </div>
+          <div class="trailing"><span class="severity-badge severity-critical">8</span></div>
+        </div>
+        <div class="divider"></div>
+        <div class="list-item">
+          <div class="leading"><span class="material-symbols-outlined">psychology</span></div>
+          <div class="content">
+            <div class="headline">Anxiety</div>
+            <div class="supporting">2 days ago</div>
+          </div>
+          <div class="trailing"><span class="severity-badge severity-mid">5</span></div>
+        </div>
+        <div class="divider"></div>
+        <div class="list-item">
+          <div class="leading"><span class="material-symbols-outlined">bolt</span></div>
+          <div class="content">
+            <div class="headline">Muscle stiffness</div>
+            <div class="supporting">3 days ago &middot; Neck</div>
+          </div>
+          <div class="trailing"><span class="severity-badge severity-low">3</span></div>
+        </div>
+      </div>
+      <button class="fab" onclick="openModal('log-symptom')">
+        <span class="material-symbols-outlined">add</span>
+      </button>
+    </div>
+
+    <!-- ═══════════ 3. PRACTICES ═══════════ -->
+    <div class="screen" id="screen-practices" data-tab="practices">
+      <div class="app-bar">
+        <h1>Practices</h1>
+      </div>
+      <div class="screen-content">
+        <div class="seg-group">
+          <button class="seg-btn active" onclick="segToggle(this)">Active</button>
+          <button class="seg-btn" onclick="segToggle(this)">All</button>
+        </div>
+
+        <div class="section-header">Supplements</div>
+        <div class="list-item">
+          <div class="leading"><span class="material-symbols-outlined">medication</span></div>
+          <div class="content">
+            <div class="headline">Magnesium glycinate</div>
+            <div class="supporting">2x/day &middot; Completion</div>
+          </div>
+          <div class="trailing"><span class="severity-badge severity-mid" style="font-size:11px;width:auto;padding:0 8px">1/2</span></div>
+        </div>
+        <div class="list-item">
+          <div class="leading"><span class="material-symbols-outlined">medication</span></div>
+          <div class="content">
+            <div class="headline">Vitamin D</div>
+            <div class="supporting">1x/day &middot; Completion</div>
+          </div>
+          <div class="trailing"><span class="severity-badge severity-low" style="font-size:11px;width:auto;padding:0 8px">1/1</span></div>
+        </div>
+        <div class="list-item">
+          <div class="leading"><span class="material-symbols-outlined">local_drink</span></div>
+          <div class="content">
+            <div class="headline">Adrenal cocktail</div>
+            <div class="supporting">1x/day &middot; Completion</div>
+          </div>
+          <div class="trailing"><span class="severity-badge severity-low" style="font-size:11px;width:auto;padding:0 8px">1/1</span></div>
+        </div>
+
+        <div class="section-header">Exercise</div>
+        <div class="list-item">
+          <div class="leading"><span class="material-symbols-outlined">directions_walk</span></div>
+          <div class="content">
+            <div class="headline">Morning walk</div>
+            <div class="supporting">Daily &middot; Completion</div>
+          </div>
+          <div class="trailing"><span class="severity-badge severity-low" style="font-size:11px;width:auto;padding:0 8px">1/1</span></div>
+        </div>
+        <div class="list-item">
+          <div class="leading"><span class="material-symbols-outlined">fitness_center</span></div>
+          <div class="content">
+            <div class="headline">Pilates routine</div>
+            <div class="supporting">3x/week &middot; Completion</div>
+          </div>
+          <div class="trailing"><span class="severity-badge severity-mid" style="font-size:11px;width:auto;padding:0 8px">0/1</span></div>
+        </div>
+
+        <div class="section-header">Mindfulness</div>
+        <div class="list-item">
+          <div class="leading"><span class="material-symbols-outlined">self_improvement</span></div>
+          <div class="content">
+            <div class="headline">Evening meditation</div>
+            <div class="supporting">Daily &middot; Completion</div>
+          </div>
+          <div class="trailing"><span class="severity-badge severity-mid" style="font-size:11px;width:auto;padding:0 8px">0/1</span></div>
+        </div>
+
+        <div class="section-header">Nutrition</div>
+        <div class="list-item">
+          <div class="leading"><span class="material-symbols-outlined">water_drop</span></div>
+          <div class="content">
+            <div class="headline">Hydration tracking</div>
+            <div class="supporting">Daily &middot; Metric &middot; Target: 8 glasses</div>
+          </div>
+          <div class="trailing"><span class="severity-badge severity-mid" style="font-size:11px;width:auto;padding:0 8px">4/8</span></div>
+        </div>
+
+        <div class="spacer"></div>
+      </div>
+      <button class="fab" onclick="openModal('create-practice')">
+        <span class="material-symbols-outlined">add</span>
+      </button>
+    </div>
+
+    <!-- ═══════════ 4. INSIGHTS ═══════════ -->
+    <div class="screen" id="screen-insights" data-tab="insights">
+      <div class="app-bar">
+        <h1>Insights</h1>
+      </div>
+      <div class="screen-content">
+        <div class="seg-group" id="insightsSeg">
+          <button class="seg-btn active" onclick="switchInsightsTab(this, 'charts')">Charts</button>
+          <button class="seg-btn" onclick="switchInsightsTab(this, 'ai')">AI Insights</button>
+          <button class="seg-btn" onclick="switchInsightsTab(this, 'reports')">Reports</button>
+        </div>
+
+        <!-- Charts View -->
+        <div class="insights-view active" id="insights-charts">
+          <div class="chip-row">
+            <button class="chip active" onclick="filterChip(this)">Week</button>
+            <button class="chip" onclick="filterChip(this)">Month</button>
+            <button class="chip" onclick="filterChip(this)">3M</button>
+            <button class="chip" onclick="filterChip(this)">6M</button>
+          </div>
+
+          <div class="chart-container">
+            <svg viewBox="0 0 320 180" width="100%">
+              <!-- Grid lines -->
+              <line x1="40" y1="20" x2="40" y2="140" stroke="var(--surface-variant)" stroke-width="1"/>
+              <line x1="40" y1="140" x2="310" y2="140" stroke="var(--surface-variant)" stroke-width="1"/>
+              <line x1="40" y1="80" x2="310" y2="80" stroke="var(--surface-variant)" stroke-width="0.5" stroke-dasharray="4"/>
+              <line x1="40" y1="20" x2="310" y2="20" stroke="var(--surface-variant)" stroke-width="0.5" stroke-dasharray="4"/>
+              <!-- Y labels -->
+              <text x="30" y="144" fill="var(--on-surface-variant)" font-size="10" text-anchor="end">0</text>
+              <text x="30" y="84" fill="var(--on-surface-variant)" font-size="10" text-anchor="end">5</text>
+              <text x="30" y="24" fill="var(--on-surface-variant)" font-size="10" text-anchor="end">10</text>
+              <!-- X labels -->
+              <text x="60" y="158" fill="var(--on-surface-variant)" font-size="10" text-anchor="middle">Mon</text>
+              <text x="105" y="158" fill="var(--on-surface-variant)" font-size="10" text-anchor="middle">Tue</text>
+              <text x="150" y="158" fill="var(--on-surface-variant)" font-size="10" text-anchor="middle">Wed</text>
+              <text x="195" y="158" fill="var(--on-surface-variant)" font-size="10" text-anchor="middle">Thu</text>
+              <text x="240" y="158" fill="var(--on-surface-variant)" font-size="10" text-anchor="middle">Fri</text>
+              <text x="285" y="158" fill="var(--on-surface-variant)" font-size="10" text-anchor="middle">Sat</text>
+              <!-- Migraine line -->
+              <polyline points="60,56 105,80 150,44 195,68 240,92 285,56" fill="none" stroke="var(--primary)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+              <circle cx="60" cy="56" r="4" fill="var(--primary)"/>
+              <circle cx="105" cy="80" r="4" fill="var(--primary)"/>
+              <circle cx="150" cy="44" r="4" fill="var(--primary)"/>
+              <circle cx="195" cy="68" r="4" fill="var(--primary)"/>
+              <circle cx="240" cy="92" r="4" fill="var(--primary)"/>
+              <circle cx="285" cy="56" r="4" fill="var(--primary)"/>
+              <!-- Fatigue line -->
+              <polyline points="60,92 105,80 150,92 195,104 240,80 285,92" fill="none" stroke="var(--secondary)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6 3"/>
+              <circle cx="60" cy="92" r="4" fill="var(--secondary)"/>
+              <circle cx="105" cy="80" r="4" fill="var(--secondary)"/>
+              <circle cx="150" cy="92" r="4" fill="var(--secondary)"/>
+              <circle cx="195" cy="104" r="4" fill="var(--secondary)"/>
+              <circle cx="240" cy="80" r="4" fill="var(--secondary)"/>
+              <circle cx="285" cy="92" r="4" fill="var(--secondary)"/>
+            </svg>
+            <!-- Legend -->
+            <div style="display:flex;gap:16px;justify-content:center;margin-top:8px">
+              <div style="display:flex;align-items:center;gap:6px;font-size:12px">
+                <div style="width:16px;height:3px;background:var(--primary);border-radius:2px"></div> Migraine
+              </div>
+              <div style="display:flex;align-items:center;gap:6px;font-size:12px">
+                <div style="width:16px;height:3px;background:var(--secondary);border-radius:2px"></div> Fatigue
+              </div>
+            </div>
+          </div>
+
+          <div class="card-title" style="padding:0 0 8px">Compare symptoms</div>
+          <div class="chip-row">
+            <button class="chip active">Migraine</button>
+            <button class="chip active">Fatigue</button>
+            <button class="chip">Brain fog</button>
+          </div>
+        </div>
+
+        <!-- AI Insights View -->
+        <div class="insights-view" id="insights-ai">
+          <div class="insight-card">
+            <div class="insight-icon"><span class="material-symbols-outlined">trending_down</span></div>
+            <p>Your headaches <strong>decreased 40%</strong> after starting magnesium 3 weeks ago.</p>
+          </div>
+          <div class="insight-card">
+            <div class="insight-icon"><span class="material-symbols-outlined">link</span></div>
+            <p>Pain levels tend to be <strong>higher on days after poor sleep quality</strong>. Consider prioritizing your sleep hygiene routine.</p>
+          </div>
+          <div class="insight-card">
+            <div class="insight-icon"><span class="material-symbols-outlined">horizontal_rule</span></div>
+            <p>Your fatigue has been <strong>stable for the past 2 weeks</strong>, averaging 4.2/10.</p>
+          </div>
+          <div class="insight-card" style="border-left-color: var(--tertiary);">
+            <div class="insight-icon" style="color:var(--tertiary)"><span class="material-symbols-outlined">check_circle</span></div>
+            <p>Great consistency! You've completed your morning walk <strong>6 out of 7 days</strong> this week.</p>
+          </div>
+          <p class="disclaimer">AI insights are observational only and do not constitute medical advice. Always consult your healthcare provider before making treatment decisions.</p>
+        </div>
+
+        <!-- Reports View -->
+        <div class="insights-view" id="insights-reports">
+          <div class="card">
+            <div class="card-title">Doctor Reports</div>
+            <p style="font-size:14px;color:var(--on-surface-variant);margin-bottom:16px">Generate a comprehensive summary for your healthcare provider.</p>
+            <button class="btn-filled full-width" onclick="openModal('doctor-report')">
+              <span class="material-symbols-outlined" style="font-size:18px">description</span>
+              Generate Doctor Report
+            </button>
+          </div>
+          <div class="card">
+            <div class="card-title">Data Export</div>
+            <p style="font-size:14px;color:var(--on-surface-variant);margin-bottom:16px">Download your health data in CSV or JSON format.</p>
+            <button class="btn-outlined full-width">
+              <span class="material-symbols-outlined" style="font-size:18px">download</span>
+              Export All Data
+            </button>
+          </div>
+          <p style="font-size:13px;color:var(--on-surface-variant);padding:8px 0">Last report generated: February 10, 2026</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- ═══════════ 5. SETTINGS ═══════════ -->
+    <div class="screen" id="screen-settings" data-tab="settings">
+      <div class="app-bar">
+        <h1>Settings</h1>
+      </div>
+      <div class="screen-content">
+        <div class="section-header" style="padding-left:0">Account</div>
+        <div class="list-item">
+          <div class="leading"><span class="material-symbols-outlined">person</span></div>
+          <div class="content"><div class="headline">Profile</div><div class="supporting">Jordan · jordan@email.com</div></div>
+          <div class="trailing"><span class="material-symbols-outlined">chevron_right</span></div>
+        </div>
+        <div class="list-item">
+          <div class="leading"><span class="material-symbols-outlined">lock</span></div>
+          <div class="content"><div class="headline">Change Password</div></div>
+          <div class="trailing"><span class="material-symbols-outlined">chevron_right</span></div>
+        </div>
+
+        <div class="section-header" style="padding-left:0">Preferences</div>
+        <div class="list-item">
+          <div class="leading"><span class="material-symbols-outlined">notifications</span></div>
+          <div class="content"><div class="headline">Notification Settings</div><div class="supporting">Reminders, journals, medications</div></div>
+          <div class="trailing"><span class="material-symbols-outlined">chevron_right</span></div>
+        </div>
+        <div class="list-item">
+          <div class="leading"><span class="material-symbols-outlined">palette</span></div>
+          <div class="content"><div class="headline">Appearance</div><div class="supporting">Theme, text size</div></div>
+          <div class="trailing"><span class="material-symbols-outlined">chevron_right</span></div>
+        </div>
+
+        <div class="section-header" style="padding-left:0">Data</div>
+        <div class="list-item">
+          <div class="leading"><span class="material-symbols-outlined">download</span></div>
+          <div class="content"><div class="headline">Export Data</div><div class="supporting">CSV, JSON, PDF reports</div></div>
+          <div class="trailing"><span class="material-symbols-outlined">chevron_right</span></div>
+        </div>
+        <div class="list-item">
+          <div class="leading"><span class="material-symbols-outlined">shield</span></div>
+          <div class="content"><div class="headline">Privacy Policy</div></div>
+          <div class="trailing"><span class="material-symbols-outlined">chevron_right</span></div>
+        </div>
+
+        <div class="section-header" style="padding-left:0">About</div>
+        <div class="list-item">
+          <div class="leading"><span class="material-symbols-outlined">info</span></div>
+          <div class="content"><div class="headline">Version</div><div class="supporting">1.0.0 (MVP)</div></div>
+        </div>
+        <div class="list-item">
+          <div class="leading"><span class="material-symbols-outlined">gavel</span></div>
+          <div class="content"><div class="headline">Terms of Service</div></div>
+          <div class="trailing"><span class="material-symbols-outlined">chevron_right</span></div>
+        </div>
+        <div class="list-item">
+          <div class="leading"><span class="material-symbols-outlined">help</span></div>
+          <div class="content"><div class="headline">Help &amp; Support</div></div>
+          <div class="trailing"><span class="material-symbols-outlined">chevron_right</span></div>
+        </div>
+
+        <div class="spacer"></div>
+        <button class="btn-outlined error full-width">
+          <span class="material-symbols-outlined" style="font-size:18px">logout</span>
+          Sign Out
+        </button>
+        <div class="spacer"></div>
+      </div>
+    </div>
+
+    <!-- ═══════════ MODAL: LOG SYMPTOM ═══════════ -->
+    <div class="modal-overlay" id="modal-log-symptom">
+      <div class="modal-header">
+        <button class="modal-close" onclick="closeModal('log-symptom')"><span class="material-symbols-outlined">close</span></button>
+        <span class="modal-title">Log Symptom</span>
+        <span class="modal-step" id="logSymptomStep">Step 1 of 4</span>
+      </div>
+      <div class="modal-body">
+        <!-- Step 1: Category -->
+        <div class="wizard-step active" data-wizard="log-symptom" data-step="1">
+          <p style="font-size:14px;color:var(--on-surface-variant);margin-bottom:16px">What type of symptom?</p>
+          <div class="category-card" onclick="selectCategory(this, 'Physical')">
+            <div class="cat-icon"><span class="material-symbols-outlined">accessibility_new</span></div>
+            <div><div class="cat-label">Physical</div><div class="cat-desc">Pain, fatigue, digestive, etc.</div></div>
+          </div>
+          <div class="category-card" onclick="selectCategory(this, 'Mental / Emotional')">
+            <div class="cat-icon"><span class="material-symbols-outlined">psychology</span></div>
+            <div><div class="cat-label">Mental / Emotional</div><div class="cat-desc">Mood, cognitive, anxiety, etc.</div></div>
+          </div>
+          <div class="category-card" onclick="selectCategory(this, 'Sleep')">
+            <div class="cat-icon"><span class="material-symbols-outlined">bed</span></div>
+            <div><div class="cat-label">Sleep</div><div class="cat-desc">Insomnia, restlessness, etc.</div></div>
+          </div>
+        </div>
+
+        <!-- Step 2: Symptom Picker -->
+        <div class="wizard-step" data-wizard="log-symptom" data-step="2">
+          <div class="form-group">
+            <input type="text" class="input-outlined" placeholder="Search symptoms...">
+          </div>
+          <div id="symptomPickerList">
+            <div class="symptom-option" onclick="selectSymptom(this)"><div class="radio"></div><span>Migraine</span></div>
+            <div class="symptom-option" onclick="selectSymptom(this)"><div class="radio"></div><span>Headache (tension)</span></div>
+            <div class="symptom-option" onclick="selectSymptom(this)"><div class="radio"></div><span>Joint pain</span></div>
+            <div class="symptom-option" onclick="selectSymptom(this)"><div class="radio"></div><span>Muscle pain</span></div>
+            <div class="symptom-option" onclick="selectSymptom(this)"><div class="radio"></div><span>Nausea</span></div>
+            <div class="symptom-option" onclick="selectSymptom(this)"><div class="radio"></div><span>Fatigue</span></div>
+            <div class="symptom-option" onclick="selectSymptom(this)"><div class="radio"></div><span>Dizziness</span></div>
+            <div class="symptom-option" onclick="selectSymptom(this)"><div class="radio"></div><span>Muscle stiffness</span></div>
+          </div>
+        </div>
+
+        <!-- Step 3: Severity -->
+        <div class="wizard-step" data-wizard="log-symptom" data-step="3">
+          <p style="font-size:14px;color:var(--on-surface-variant);margin-bottom:24px">How severe is it?</p>
+          <div style="text-align:center;margin-bottom:8px">
+            <div style="font-size:48px;font-weight:300;color:var(--primary)" id="severityNum">5</div>
+            <div style="font-size:16px;color:var(--on-surface-variant)" id="severityLabel">Moderate</div>
+          </div>
+          <div class="spacer"></div>
+          <input type="range" min="0" max="10" value="5" oninput="updateSeverity(this.value)" style="margin-bottom:16px">
+          <div style="display:flex;justify-content:space-between;font-size:11px;color:var(--on-surface-variant)">
+            <span>None</span><span>Mild</span><span>Moderate</span><span>Severe</span><span>Worst</span>
+          </div>
+        </div>
+
+        <!-- Step 4: Details -->
+        <div class="wizard-step" data-wizard="log-symptom" data-step="4">
+          <p style="font-size:14px;color:var(--on-surface-variant);margin-bottom:16px">Optional details</p>
+          <div class="form-group">
+            <label class="input-label">Body location</label>
+            <select class="input-outlined" style="cursor:pointer">
+              <option value="">Select location...</option>
+              <option>Head — Left temple</option>
+              <option>Head — Right temple</option>
+              <option>Head — Forehead</option>
+              <option>Neck</option>
+              <option>Upper back</option>
+              <option>Lower back</option>
+              <option>Knees</option>
+              <option>Hands/fingers</option>
+              <option>General/widespread</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label class="input-label">Duration</label>
+            <div class="inline-fields">
+              <input type="number" class="input-outlined" placeholder="Amount" value="2">
+              <select class="input-outlined" style="cursor:pointer">
+                <option>hours</option>
+                <option>minutes</option>
+                <option>days</option>
+              </select>
+            </div>
+          </div>
+          <div class="toggle-row">
+            <span style="font-size:14px">Ongoing</span>
+            <div class="toggle" onclick="this.classList.toggle('on')"></div>
+          </div>
+          <div class="form-group">
+            <label class="input-label">Notes</label>
+            <textarea class="input-outlined" rows="3" placeholder="Any additional context..." style="resize:none;font-family:inherit"></textarea>
+          </div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button class="btn-text" id="logSymptomBack" onclick="wizardBack('log-symptom')" style="visibility:hidden">Back</button>
+        <button class="btn-filled" id="logSymptomNext" onclick="wizardNext('log-symptom', 4)">Next</button>
+      </div>
+    </div>
+
+    <!-- ═══════════ MODAL: CREATE PRACTICE ═══════════ -->
+    <div class="modal-overlay" id="modal-create-practice">
+      <div class="modal-header">
+        <button class="modal-close" onclick="closeModal('create-practice')"><span class="material-symbols-outlined">close</span></button>
+        <span class="modal-title">New Practice</span>
+        <span class="modal-step" id="createPracticeStep">Step 1 of 3</span>
+      </div>
+      <div class="modal-body">
+        <!-- Step 1: Name & Category -->
+        <div class="wizard-step active" data-wizard="create-practice" data-step="1">
+          <div class="form-group">
+            <label class="input-label">Practice name</label>
+            <input type="text" class="input-outlined" placeholder="e.g., Magnesium glycinate">
+          </div>
+          <div class="form-group">
+            <label class="input-label">Category</label>
+            <select class="input-outlined" style="cursor:pointer">
+              <option value="">Select category...</option>
+              <option>Supplements</option>
+              <option>Exercise</option>
+              <option>Mindfulness</option>
+              <option>Sleep Hygiene</option>
+              <option>Nutrition</option>
+              <option>Other</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label class="input-label">Notes (optional)</label>
+            <textarea class="input-outlined" rows="2" placeholder="Dosage, instructions, links..." style="resize:none;font-family:inherit"></textarea>
+          </div>
+        </div>
+
+        <!-- Step 2: Tracking Type -->
+        <div class="wizard-step" data-wizard="create-practice" data-step="2">
+          <p style="font-size:14px;color:var(--on-surface-variant);margin-bottom:16px">How will you track this?</p>
+          <div class="radio-option selected" onclick="selectRadio(this, 'create-practice-2')">
+            <div class="radio-circle"></div>
+            <div>
+              <div class="radio-label">Completion</div>
+              <div class="radio-desc">Mark as done/skipped each time</div>
+            </div>
+          </div>
+          <div class="radio-option" onclick="selectRadio(this, 'create-practice-2')">
+            <div class="radio-circle"></div>
+            <div>
+              <div class="radio-label">Metric</div>
+              <div class="radio-desc">Log a numeric value (e.g., glasses of water)</div>
+            </div>
+          </div>
+          <div class="spacer"></div>
+          <div id="metricFields" style="display:none">
+            <div class="form-group">
+              <label class="input-label">Unit</label>
+              <input type="text" class="input-outlined" placeholder="e.g., glasses, minutes, steps">
+            </div>
+            <div class="form-group">
+              <label class="input-label">Daily target</label>
+              <input type="number" class="input-outlined" placeholder="e.g., 8">
+            </div>
+          </div>
+        </div>
+
+        <!-- Step 3: Frequency -->
+        <div class="wizard-step" data-wizard="create-practice" data-step="3">
+          <p style="font-size:14px;color:var(--on-surface-variant);margin-bottom:16px">How often?</p>
+          <div class="radio-option selected" onclick="selectRadio(this, 'create-practice-3')">
+            <div class="radio-circle"></div>
+            <div><div class="radio-label">Daily</div></div>
+          </div>
+          <div class="radio-option" onclick="selectRadio(this, 'create-practice-3')">
+            <div class="radio-circle"></div>
+            <div><div class="radio-label">Weekly</div></div>
+          </div>
+          <div class="radio-option" onclick="selectRadio(this, 'create-practice-3')">
+            <div class="radio-circle"></div>
+            <div><div class="radio-label">Specific days</div></div>
+          </div>
+          <div class="day-chips">
+            <button class="day-chip" onclick="this.classList.toggle('active')">M</button>
+            <button class="day-chip" onclick="this.classList.toggle('active')">T</button>
+            <button class="day-chip active" onclick="this.classList.toggle('active')">W</button>
+            <button class="day-chip" onclick="this.classList.toggle('active')">T</button>
+            <button class="day-chip active" onclick="this.classList.toggle('active')">F</button>
+            <button class="day-chip" onclick="this.classList.toggle('active')">S</button>
+            <button class="day-chip" onclick="this.classList.toggle('active')">S</button>
+          </div>
+          <div class="form-group">
+            <label class="input-label">Times per day</label>
+            <input type="number" class="input-outlined" value="1" min="1" max="10">
+          </div>
+          <div class="form-group">
+            <label class="input-label">Reminder time</label>
+            <input type="time" class="input-outlined" value="09:00" style="cursor:pointer">
+          </div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button class="btn-text" id="createPracticeBack" onclick="wizardBack('create-practice')" style="visibility:hidden">Back</button>
+        <button class="btn-filled" id="createPracticeNext" onclick="wizardNext('create-practice', 3)">Next</button>
+      </div>
+    </div>
+
+    <!-- ═══════════ MODAL: MORNING JOURNAL ═══════════ -->
+    <div class="modal-overlay" id="modal-morning-journal">
+      <div class="modal-header">
+        <button class="modal-close" onclick="closeModal('morning-journal')"><span class="material-symbols-outlined">close</span></button>
+        <span class="modal-title">Morning Check-in</span>
+        <span class="modal-step" style="font-size:12px">Feb 18, 2026</span>
+      </div>
+      <div class="modal-body">
+        <div class="spacer-sm"></div>
+        <div class="slider-group">
+          <div class="slider-header">
+            <span class="slider-title">Hours of sleep</span>
+            <div><span class="slider-value" id="sleepHoursVal">7</span><span class="slider-label-text" id="sleepHoursLabel"></span></div>
+          </div>
+          <input type="range" min="0" max="12" value="7" step="0.5" oninput="document.getElementById('sleepHoursVal').textContent=this.value">
+        </div>
+        <div class="slider-group">
+          <div class="slider-header">
+            <span class="slider-title">Sleep quality</span>
+            <div><span class="slider-value" id="sleepQualVal">6</span><span class="slider-label-text" id="sleepQualLabel"> — Good</span></div>
+          </div>
+          <input type="range" min="0" max="10" value="6" oninput="updateJournalSlider(this,'sleepQualVal','sleepQualLabel',['Poor','Poor','Fair','Fair','Fair','Okay','Good','Good','Great','Excellent','Excellent'])">
+        </div>
+        <div class="slider-group">
+          <div class="slider-header">
+            <span class="slider-title">Pain on waking</span>
+            <div><span class="slider-value" id="morningPainVal">3</span><span class="slider-label-text" id="morningPainLabel"> — Mild</span></div>
+          </div>
+          <input type="range" min="0" max="10" value="3" oninput="updateJournalSlider(this,'morningPainVal','morningPainLabel',['None','Minimal','Mild','Mild','Moderate','Moderate','Significant','Severe','Severe','Very severe','Worst'])">
+        </div>
+        <div class="slider-group">
+          <div class="slider-header">
+            <span class="slider-title">Energy level</span>
+            <div><span class="slider-value" id="morningEnergyVal">5</span><span class="slider-label-text" id="morningEnergyLabel"> — Moderate</span></div>
+          </div>
+          <input type="range" min="0" max="10" value="5" oninput="updateJournalSlider(this,'morningEnergyVal','morningEnergyLabel',['Exhausted','Very low','Low','Low','Moderate','Moderate','Good','Good','High','Very high','Energized'])">
+        </div>
+        <div class="form-group">
+          <label class="input-label">Notes</label>
+          <textarea class="input-outlined" rows="3" placeholder="How are you feeling this morning?" style="resize:none;font-family:inherit"></textarea>
+        </div>
+      </div>
+      <div class="modal-footer" style="justify-content:stretch">
+        <button class="btn-filled full-width" onclick="closeModal('morning-journal')">Save Check-in</button>
+      </div>
+    </div>
+
+    <!-- ═══════════ MODAL: EVENING JOURNAL ═══════════ -->
+    <div class="modal-overlay" id="modal-evening-journal">
+      <div class="modal-header">
+        <button class="modal-close" onclick="closeModal('evening-journal')"><span class="material-symbols-outlined">close</span></button>
+        <span class="modal-title">Evening Reflection</span>
+        <span class="modal-step" style="font-size:12px">Feb 18, 2026</span>
+      </div>
+      <div class="modal-body">
+        <div class="spacer-sm"></div>
+        <div class="slider-group">
+          <div class="slider-header">
+            <span class="slider-title">Overall mood</span>
+            <div><span class="slider-value" id="moodVal">6</span><span class="slider-label-text" id="moodLabel"> — Good</span></div>
+          </div>
+          <input type="range" min="0" max="10" value="6" oninput="updateJournalSlider(this,'moodVal','moodLabel',['Very poor','Poor','Low','Low','Okay','Neutral','Good','Good','Great','Excellent','Excellent'])">
+        </div>
+        <div class="slider-group">
+          <div class="slider-header">
+            <span class="slider-title">Energy throughout the day</span>
+            <div><span class="slider-value" id="eveningEnergyVal">5</span><span class="slider-label-text" id="eveningEnergyLabel"> — Moderate</span></div>
+          </div>
+          <input type="range" min="0" max="10" value="5" oninput="updateJournalSlider(this,'eveningEnergyVal','eveningEnergyLabel',['Exhausted','Very low','Low','Low','Moderate','Moderate','Good','Good','High','Very high','Energized'])">
+        </div>
+        <div class="slider-group">
+          <div class="slider-header">
+            <span class="slider-title">Overall pain</span>
+            <div><span class="slider-value" id="eveningPainVal">4</span><span class="slider-label-text" id="eveningPainLabel"> — Moderate</span></div>
+          </div>
+          <input type="range" min="0" max="10" value="4" oninput="updateJournalSlider(this,'eveningPainVal','eveningPainLabel',['None','Minimal','Mild','Mild','Moderate','Moderate','Significant','Severe','Severe','Very severe','Worst'])">
+        </div>
+        <div class="form-group">
+          <label class="input-label">Notes</label>
+          <textarea class="input-outlined" rows="3" placeholder="Reflect on your day..." style="resize:none;font-family:inherit"></textarea>
+        </div>
+      </div>
+      <div class="modal-footer" style="justify-content:stretch">
+        <button class="btn-filled full-width" onclick="closeModal('evening-journal')">Save Reflection</button>
+      </div>
+    </div>
+
+    <!-- ═══════════ MODAL: ADD MEDICATION ═══════════ -->
+    <div class="modal-overlay" id="modal-add-medication">
+      <div class="modal-header">
+        <button class="modal-close" onclick="closeModal('add-medication')"><span class="material-symbols-outlined">close</span></button>
+        <span class="modal-title">Add Medication</span>
+      </div>
+      <div class="modal-body">
+        <div class="spacer-sm"></div>
+        <div class="form-group">
+          <label class="input-label">Medication name</label>
+          <input type="text" class="input-outlined" placeholder="e.g., Ibuprofen">
+        </div>
+        <div class="form-group">
+          <label class="input-label">Dosage</label>
+          <div class="inline-fields">
+            <input type="text" class="input-outlined" placeholder="Amount" value="400">
+            <select class="input-outlined" style="cursor:pointer">
+              <option>mg</option>
+              <option>mcg</option>
+              <option>ml</option>
+              <option>IU</option>
+              <option>tablets</option>
+            </select>
+          </div>
+        </div>
+        <div class="form-group">
+          <label class="input-label">Frequency</label>
+          <div class="radio-option selected" onclick="selectRadio(this, 'med-freq')">
+            <div class="radio-circle"></div>
+            <div><div class="radio-label">Daily</div></div>
+          </div>
+          <div class="radio-option" onclick="selectRadio(this, 'med-freq')">
+            <div class="radio-circle"></div>
+            <div><div class="radio-label">Twice daily</div></div>
+          </div>
+          <div class="radio-option" onclick="selectRadio(this, 'med-freq')">
+            <div class="radio-circle"></div>
+            <div><div class="radio-label">As needed</div></div>
+          </div>
+        </div>
+        <div class="form-group">
+          <label class="input-label">Time</label>
+          <div class="chip-row">
+            <span class="chip active">9:00 AM</span>
+            <span class="chip">12:00 PM</span>
+            <span class="chip">9:00 PM</span>
+          </div>
+        </div>
+        <div class="form-group">
+          <label class="input-label">Link to symptoms</label>
+          <div class="checkbox-item checked" onclick="this.classList.toggle('checked')">
+            <div class="checkbox-box"></div><span style="font-size:14px">Migraine</span>
+          </div>
+          <div class="checkbox-item" onclick="this.classList.toggle('checked')">
+            <div class="checkbox-box"></div><span style="font-size:14px">Fatigue</span>
+          </div>
+          <div class="checkbox-item" onclick="this.classList.toggle('checked')">
+            <div class="checkbox-box"></div><span style="font-size:14px">Joint pain</span>
+          </div>
+          <div class="checkbox-item" onclick="this.classList.toggle('checked')">
+            <div class="checkbox-box"></div><span style="font-size:14px">Insomnia</span>
+          </div>
+          <div class="checkbox-item" onclick="this.classList.toggle('checked')">
+            <div class="checkbox-box"></div><span style="font-size:14px">Anxiety</span>
+          </div>
+        </div>
+      </div>
+      <div class="modal-footer" style="justify-content:stretch">
+        <button class="btn-filled full-width" onclick="closeModal('add-medication')">Save Medication</button>
+      </div>
+    </div>
+
+    <!-- ═══════════ MODAL: DOCTOR REPORT ═══════════ -->
+    <div class="modal-overlay" id="modal-doctor-report">
+      <div class="modal-header">
+        <button class="modal-close" onclick="closeModal('doctor-report')"><span class="material-symbols-outlined">arrow_back</span></button>
+        <span class="modal-title">Doctor Report</span>
+        <button class="modal-close" style="margin-left:auto"><span class="material-symbols-outlined">share</span></button>
+      </div>
+      <div class="modal-body">
+        <div style="text-align:center;margin-bottom:16px">
+          <div class="badge">
+            <span class="material-symbols-outlined" style="font-size:14px">date_range</span>
+            Jan 18 — Feb 18, 2026
+          </div>
+        </div>
+
+        <div class="report-card">
+          <h3>Symptom Summary</h3>
+          <div class="report-row"><span class="label">Migraine</span><span class="value">avg 6.2/10 · 8 episodes</span></div>
+          <div class="report-row"><span class="label">Fatigue</span><span class="value">avg 4.5/10 · 12 episodes</span></div>
+          <div class="report-row"><span class="label">Joint pain</span><span class="value">avg 5.1/10 · 6 episodes</span></div>
+          <div class="report-row"><span class="label">Brain fog</span><span class="value">avg 4.8/10 · 9 episodes</span></div>
+          <div class="report-row"><span class="label">Insomnia</span><span class="value">avg 6.0/10 · 4 episodes</span></div>
+        </div>
+
+        <div class="report-card">
+          <h3>Medications &amp; Supplements</h3>
+          <div class="report-row"><span class="label">Magnesium glycinate</span><span class="value">89% adherence</span></div>
+          <div class="report-row"><span class="label">Vitamin D</span><span class="value">93% adherence</span></div>
+          <div class="report-row"><span class="label">Adrenal cocktail</span><span class="value">78% adherence</span></div>
+        </div>
+
+        <div class="report-card">
+          <h3>Health Practices</h3>
+          <div class="report-row"><span class="label">Morning walk</span><span class="value">85% adherence</span></div>
+          <div class="report-row"><span class="label">Pilates routine</span><span class="value">67% adherence</span></div>
+          <div class="report-row"><span class="label">Evening meditation</span><span class="value">71% adherence</span></div>
+          <div class="report-row"><span class="label">Hydration</span><span class="value">avg 5.8/8 glasses</span></div>
+        </div>
+
+        <div class="report-card" style="border-left:3px solid var(--secondary)">
+          <h3>AI Observations</h3>
+          <p style="font-size:13px;color:var(--on-surface-variant);line-height:1.5;margin-bottom:8px">Headache frequency decreased after starting magnesium. Pain levels correlate with sleep quality. Fatigue remained stable across the period.</p>
+          <p class="disclaimer" style="padding:0;margin:0">AI-generated observations. Not medical advice.</p>
+        </div>
+      </div>
+      <div class="modal-footer" style="justify-content:stretch">
+        <button class="btn-filled full-width" onclick="closeModal('doctor-report')">
+          <span class="material-symbols-outlined" style="font-size:18px">picture_as_pdf</span>
+          Download PDF
+        </button>
+      </div>
+    </div>
+
+  </div><!-- end screen-area -->
+
+  <!-- Bottom Navigation -->
+  <nav class="bottom-nav" id="bottomNav">
+    <button class="tab-btn active" data-tab="home" onclick="goTo('home')">
+      <div class="icon-wrap"><span class="material-symbols-outlined">home</span></div>
+      <span class="label">Home</span>
+    </button>
+    <button class="tab-btn" data-tab="symptoms" onclick="goTo('symptoms')">
+      <div class="icon-wrap"><span class="material-symbols-outlined">monitor_heart</span></div>
+      <span class="label">Symptoms</span>
+    </button>
+    <button class="tab-btn" data-tab="practices" onclick="goTo('practices')">
+      <div class="icon-wrap"><span class="material-symbols-outlined">spa</span></div>
+      <span class="label">Practices</span>
+    </button>
+    <button class="tab-btn" data-tab="insights" onclick="goTo('insights')">
+      <div class="icon-wrap"><span class="material-symbols-outlined">insights</span></div>
+      <span class="label">Insights</span>
+    </button>
+    <button class="tab-btn" data-tab="settings" onclick="goTo('settings')">
+      <div class="icon-wrap"><span class="material-symbols-outlined">settings</span></div>
+      <span class="label">Settings</span>
+    </button>
+  </nav>
+
+</div><!-- end phone -->
+
+</div><!-- end page-wrapper -->
+
+<script>
+/* ═══════════ NAVIGATION ═══════════ */
+const wizardState = {};
+
+function goTo(tab) {
+  // Close any open modal first
+  document.querySelectorAll('.modal-overlay.active').forEach(m => m.classList.remove('active'));
+  document.getElementById('phone').classList.remove('modal-open');
+
+  // Switch screen
+  document.querySelectorAll('.screen').forEach(s => s.classList.remove('active'));
+  const screen = document.getElementById('screen-' + tab);
+  if (screen) screen.classList.add('active');
+
+  // Update bottom nav
+  document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+  const btn = document.querySelector(`.tab-btn[data-tab="${tab}"]`);
+  if (btn) btn.classList.add('active');
+
+  // Update sidebar
+  document.querySelectorAll('.screen-nav button').forEach(b => b.classList.remove('active'));
+  const navBtn = [...document.querySelectorAll('.screen-nav button')].find(b => b.textContent.trim().toLowerCase().startsWith(tab));
+  if (navBtn) navBtn.classList.add('active');
+
+  // Update hash
+  history.replaceState(null, '', '#' + tab);
+}
+
+function openModal(id) {
+  // Reset wizard state
+  wizardState[id] = 1;
+  const steps = document.querySelectorAll(`[data-wizard="${id}"]`);
+  steps.forEach(s => s.classList.remove('active'));
+  if (steps[0]) steps[0].classList.add('active');
+
+  // Update step indicators
+  updateWizardUI(id);
+
+  // Show modal
+  const modal = document.getElementById('modal-' + id);
+  if (modal) {
+    modal.classList.add('active');
+    document.getElementById('phone').classList.add('modal-open');
+  }
+
+  // Update sidebar
+  document.querySelectorAll('.screen-nav button').forEach(b => b.classList.remove('active'));
+  const label = id.replace(/-/g, ' ');
+  const navBtn = [...document.querySelectorAll('.screen-nav button')].find(b =>
+    b.textContent.trim().toLowerCase() === label
+  );
+  if (navBtn) navBtn.classList.add('active');
+}
+
+function closeModal(id) {
+  const modal = document.getElementById('modal-' + id);
+  if (modal) modal.classList.remove('active');
+  document.getElementById('phone').classList.remove('modal-open');
+
+  // Re-highlight current tab in sidebar
+  const activeTab = document.querySelector('.tab-btn.active');
+  if (activeTab) {
+    const tab = activeTab.dataset.tab;
+    const navBtn = [...document.querySelectorAll('.screen-nav button')].find(b =>
+      b.textContent.trim().toLowerCase().startsWith(tab)
+    );
+    document.querySelectorAll('.screen-nav button').forEach(b => b.classList.remove('active'));
+    if (navBtn) navBtn.classList.add('active');
+  }
+}
+
+/* ═══════════ WIZARD NAVIGATION ═══════════ */
+function wizardNext(wizard, totalSteps) {
+  const current = wizardState[wizard] || 1;
+  if (current >= totalSteps) {
+    closeModal(wizard);
+    return;
+  }
+  wizardState[wizard] = current + 1;
+  showWizardStep(wizard);
+}
+
+function wizardBack(wizard) {
+  const current = wizardState[wizard] || 1;
+  if (current <= 1) return;
+  wizardState[wizard] = current - 1;
+  showWizardStep(wizard);
+}
+
+function showWizardStep(wizard) {
+  const step = wizardState[wizard];
+  document.querySelectorAll(`[data-wizard="${wizard}"]`).forEach(s => {
+    s.classList.toggle('active', parseInt(s.dataset.step) === step);
+  });
+  updateWizardUI(wizard);
+}
+
+function updateWizardUI(wizard) {
+  const step = wizardState[wizard] || 1;
+  const totalSteps = document.querySelectorAll(`[data-wizard="${wizard}"]`).length;
+
+  // Step indicator
+  const indicator = document.getElementById(wizard.replace(/-([a-z])/g, (_, c) => c.toUpperCase()) + 'Step');
+  if (indicator) indicator.textContent = `Step ${step} of ${totalSteps}`;
+
+  // Back button visibility
+  const backBtn = document.getElementById(wizard.replace(/-([a-z])/g, (_, c) => c.toUpperCase()) + 'Back');
+  if (backBtn) backBtn.style.visibility = step === 1 ? 'hidden' : 'visible';
+
+  // Next button text
+  const nextBtn = document.getElementById(wizard.replace(/-([a-z])/g, (_, c) => c.toUpperCase()) + 'Next');
+  if (nextBtn) nextBtn.textContent = step === totalSteps ? 'Save' : 'Next';
+}
+
+/* ═══════════ INTERACTIVE ELEMENTS ═══════════ */
+
+// Task toggle
+function toggleTask(el) {
+  el.classList.toggle('done');
+  updateProgress();
+}
+
+function updateProgress() {
+  const tasks = document.querySelectorAll('#taskList .task-item');
+  const done = document.querySelectorAll('#taskList .task-item.done').length;
+  const total = tasks.length;
+  const pct = done / total;
+
+  document.getElementById('progressText').textContent = `${done}/${total} tasks`;
+
+  const circumference = 314;
+  const arc = pct * circumference;
+  document.getElementById('progressArc').setAttribute('stroke-dasharray', `${arc} ${circumference}`);
+}
+
+// Severity slider
+const severityLabels = ['None','Minimal','Mild','Mild','Moderate','Moderate','Significant','Severe','Severe','Very severe','Worst imaginable'];
+function updateSeverity(val) {
+  document.getElementById('severityNum').textContent = val;
+  document.getElementById('severityLabel').textContent = severityLabels[parseInt(val)];
+}
+
+// Journal sliders
+function updateJournalSlider(input, valId, labelId, labels) {
+  const val = parseInt(input.value);
+  document.getElementById(valId).textContent = input.value;
+  document.getElementById(labelId).textContent = ' — ' + labels[val];
+}
+
+// Filter chips (single-select within row)
+function filterChip(el) {
+  el.parentElement.querySelectorAll('.chip').forEach(c => c.classList.remove('active'));
+  el.classList.add('active');
+}
+
+// Segmented buttons
+function segToggle(el) {
+  el.parentElement.querySelectorAll('.seg-btn').forEach(b => b.classList.remove('active'));
+  el.classList.add('active');
+}
+
+// Insights tab switcher
+function switchInsightsTab(el, view) {
+  el.parentElement.querySelectorAll('.seg-btn').forEach(b => b.classList.remove('active'));
+  el.classList.add('active');
+  document.querySelectorAll('.insights-view').forEach(v => v.classList.remove('active'));
+  const target = document.getElementById('insights-' + view);
+  if (target) target.classList.add('active');
+}
+
+// Category selection (Log Symptom step 1)
+function selectCategory(el, name) {
+  el.parentElement.querySelectorAll('.category-card').forEach(c => c.classList.remove('selected'));
+  el.classList.add('selected');
+}
+
+// Symptom selection (Log Symptom step 2)
+function selectSymptom(el) {
+  el.parentElement.querySelectorAll('.symptom-option').forEach(o => o.classList.remove('selected'));
+  el.classList.add('selected');
+}
+
+// Radio selection
+function selectRadio(el, group) {
+  const parent = el.closest('.modal-body') || el.closest('.wizard-step');
+  const siblings = parent.querySelectorAll(`.radio-option`);
+  // Only deselect radios in the same logical group
+  let radioGroup = el.parentElement;
+  // Simple: deselect all radio-options that are direct siblings
+  let node = el.parentElement.firstElementChild;
+  while (node) {
+    if (node.classList && node.classList.contains('radio-option')) {
+      node.classList.remove('selected');
+    }
+    node = node.nextElementSibling;
+  }
+  el.classList.add('selected');
+}
+
+// Quick log symptom (from Home)
+function quickLogSymptom(name) {
+  openModal('log-symptom');
+  // Jump to step 3 (severity)
+  wizardState['log-symptom'] = 3;
+  showWizardStep('log-symptom');
+}
+
+/* ═══════════ INSIGHTS VIEW TOGGLE ═══════════ */
+// CSS helper for insights views
+document.querySelectorAll('.insights-view').forEach(v => {
+  if (!v.classList.contains('active')) v.style.display = 'none';
+});
+
+// Override to handle display
+const origSwitchInsights = switchInsightsTab;
+switchInsightsTab = function(el, view) {
+  el.parentElement.querySelectorAll('.seg-btn').forEach(b => b.classList.remove('active'));
+  el.classList.add('active');
+  document.querySelectorAll('.insights-view').forEach(v => {
+    v.classList.remove('active');
+    v.style.display = 'none';
+  });
+  const target = document.getElementById('insights-' + view);
+  if (target) {
+    target.classList.add('active');
+    target.style.display = 'block';
+  }
+};
+
+/* ═══════════ INIT ═══════════ */
+// Handle initial hash
+const hash = window.location.hash.slice(1);
+if (hash && document.getElementById('screen-' + hash)) {
+  goTo(hash);
+}
+
+// Initialize progress
+updateProgress();
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

- **Interactive HTML wireframe** (`wireframes/flare-mvp.html`) — a clickable phone prototype covering all 11 MVP screens, styled to match React Native Paper / Material Design 3 with a calming teal/lavender palette
- **Project README** documenting tech stack, setup instructions, project structure, and security posture

## Wireframe Details

**5 Tab Screens:** Home (daily task hub with live progress ring), Symptoms (filterable history), Practices (grouped by category), Insights (charts, AI insights, reports), Settings

**6 Modal Flows:** Log Symptom (4-step wizard), Create Practice (3-step wizard), Morning Journal, Evening Journal, Add Medication, Doctor Report

**Interactive elements:** Task checkboxes update progress ring, severity sliders with live labels, filter chips, segmented buttons, multi-step wizard navigation, quick-log symptom chips that jump to severity step

## Purpose

Establishes the visual specification for all MVP features before creating GitHub milestones and issues. Open the HTML file in any browser to click through the full user experience — no dependencies required.

## Test plan

- [ ] Open `wireframes/flare-mvp.html` in browser — phone frame renders centered
- [ ] Click all 5 bottom tabs — screens switch, active tab highlights
- [ ] Toggle task checkboxes on Home — progress ring updates
- [ ] Click "Log Symptom" quick action — 4-step wizard navigates correctly
- [ ] Click frequent symptom chip — jumps to severity step (step 3)
- [ ] Open Morning/Evening Journal — sliders show live values with labels
- [ ] Navigate Insights sub-tabs (Charts/AI/Reports) — content switches
- [ ] Use sidebar navigation to jump between any screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)